### PR TITLE
Refactored permission granting into trait

### DIFF
--- a/src/PermissibleModelTrait.php
+++ b/src/PermissibleModelTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Rhubarb\Scaffolds\AuthenticationWithRoles;
+
+use Rhubarb\Stem\Exceptions\RecordNotFoundException;
+use Rhubarb\Stem\Filters\AndGroup;
+use Rhubarb\Stem\Filters\Equals;
+use Rhubarb\Stem\Models\Model;
+
+/**
+ * Helpful methods for models which can be granted permissions using a PermissionAssignment record
+ */
+trait PermissibleModelTrait
+{
+
+    /**
+     * @param Permission $permission
+     *
+     * @throws PermissionException
+     */
+    public function allow(Permission $permission)
+    {
+        $this->setPermissionSetting($permission, true);
+    }
+
+    /**
+     * @param Permission $permission
+     *
+     * @throws PermissionException
+     */
+    public function deny(Permission $permission)
+    {
+        $this->setPermissionSetting($permission, false);
+    }
+
+    /**
+     * @param Permission $permission
+     * @param bool|true  $allowed
+     *
+     * @throws PermissionException
+     * @throws \Exception
+     * @throws \Rhubarb\Stem\Exceptions\ModelConsistencyValidationException
+     */
+    protected function setPermissionSetting(Permission $permission, $allowed = true)
+    {
+        /** @var Model $this */
+        if ($permission->isNewRecord()) {
+            throw new PermissionException("The permission has not been saved.");
+        }
+
+        if ($this->isNewRecord()) {
+            throw new PermissionException("The model has not been saved.");
+        }
+
+        $foreignKeyField = $this->getUniqueIdentifierColumnName();
+        $foreignKeyValue = $this->getUniqueIdentifier();
+        try {
+            $assignment = PermissionAssignment::findFirst(
+                new AndGroup([
+                    new Equals('PermissionID', $permission->PermissionID),
+                    new Equals($foreignKeyField, $foreignKeyValue)
+                ])
+            );
+        } catch (RecordNotFoundException $ex) {
+            $assignment = new PermissionAssignment();
+            $assignment->PermissionID = $permission->PermissionID;
+            $assignment->$foreignKeyField = $foreignKeyValue;
+        }
+        $assignment->Access = $allowed ? 'Allowed' : 'Denied';
+        $assignment->save();
+    }
+}

--- a/src/Role.php
+++ b/src/Role.php
@@ -21,7 +21,6 @@ namespace Rhubarb\Scaffolds\AuthenticationWithRoles;
 use Rhubarb\Stem\Filters\Equals;
 use Rhubarb\Stem\Filters\OrGroup;
 use Rhubarb\Stem\Models\Model;
-use Rhubarb\Stem\Repositories\MySql\Schema\MySqlModelSchema;
 use Rhubarb\Stem\Schema\Columns\AutoIncrement;
 use Rhubarb\Stem\Schema\Columns\String;
 use Rhubarb\Stem\Schema\ModelSchema;
@@ -32,6 +31,9 @@ use Rhubarb\Stem\Schema\ModelSchema;
  */
 class Role extends Model
 {
+
+    use PermissibleModelTrait;
+
     /**
      * Returns the schema for this data object.
      *

--- a/src/User.php
+++ b/src/User.php
@@ -25,38 +25,14 @@ use Rhubarb\Stem\Schema\ModelSchema;
 
 class User extends \Rhubarb\Scaffolds\Authentication\User
 {
+
+    use PermissibleModelTrait;
+
     protected function extendSchema(ModelSchema $schema)
     {
         $schema->addColumn(new ForeignKey("RoleID"));
 
         parent::extendSchema($schema);
-    }
-
-    public function allow(Permission $permission)
-    {
-        $this->setPermissionSetting($permission, true);
-    }
-
-    public function deny(Permission $permission)
-    {
-        $this->setPermissionSetting($permission, false);
-    }
-
-    private function setPermissionSetting(Permission $permission, $allowed = true)
-    {
-        if ($permission->isNewRecord()) {
-            throw new PermissionException("The permission has not been saved.");
-        }
-
-        if ($this->isNewRecord()) {
-            throw new PermissionException("The user has not been saved.");
-        }
-
-        $assignment = new PermissionAssignment();
-        $assignment->PermissionID = $permission->PermissionID;
-        $assignment->UserID = $this->UniqueIdentifier;
-        $assignment->Access = ($allowed) ? "Allowed" : "Denied";
-        $assignment->save();
     }
 
     public function can($permissionPath)


### PR DESCRIPTION
implemented `allow()` and `deny()` in a trait so that `User` and `Role` can use the same logic
